### PR TITLE
fix docker compose healthcheck

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -37,7 +37,6 @@ services:
           "curl",
           "http://127.0.0.1:${SERVER_PORT}/meditations"
         ]
-      interval: 2s
       timeout: 2s
       retries: 10
 


### PR DESCRIPTION
In docker-compose.yml, remove the health check interval to ensure that the health check stops after succeeding