### PR TITLE
add endpoint for ready check to REST server; fix docker-compose healt…

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -32,11 +32,9 @@ services:
       - ${MODEL_PATH}:/app/models
     healthcheck:
       test:
-        [
-          "CMD",
-          "curl",
-          "http://127.0.0.1:${SERVER_PORT}/meditations"
-        ]
-      timeout: 2s
-      retries: 10
+        [ "CMD", "curl", "-f", "http://127.0.0.1:${SERVER_PORT}/ready" ]
+      interval: 30s
+      timeout: 5s
+      retries: 2
+      start_period: 10s
 

--- a/src/routes/service_routes.py
+++ b/src/routes/service_routes.py
@@ -1,0 +1,16 @@
+import sqlalchemy
+from flask import Blueprint
+from flask import jsonify
+
+service_routes = Blueprint('service_routes', __name__)
+from models import MeditationSession
+
+
+@service_routes.route("/ready", methods=['GET'])
+def get_meditation_sessions():
+    # check whether database is reachable
+    try:
+        MeditationSession.query.all()
+    except sqlalchemy.exc.OperationalError:
+        return jsonify({'error': 'database not reachable'}), 503
+    return jsonify({'message': 'server is ready'}), 200

--- a/src/server.py
+++ b/src/server.py
@@ -3,6 +3,7 @@ import os
 from flask import Flask
 from dotenv import load_dotenv
 from routes.lstm_routes import lstm_routes
+from routes.service_routes import service_routes
 from models import db
 from routes.meditation_routes import meditation_routes
 
@@ -25,6 +26,7 @@ app.config['app'] = app
 
 app.register_blueprint(lstm_routes)
 app.register_blueprint(meditation_routes)
+app.register_blueprint(service_routes)
 
 if __name__ == '__main__':
     with app.app_context():


### PR DESCRIPTION
- implement separate endpoint to perform ready check, which was necessary, because docker compose is constantly checking the health status of the backend container
  - prevents 404 errors in logs  
  - checks also whether database is available
 - update docker-compose.yml file using new healthcheck endpoint
